### PR TITLE
Makefile: fix CLFAGS typo

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,8 @@ git
 
   * Documentation and error message updates.
 
+  * Fixed CLFAGS typo in makefile
+
 v4.6 09-March-2024
   * Took over ownership of project, since last version was over a decade ago. Changed associated URLs.
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ crond: $(OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ $(LIBS) -o crond
 
 crontab: $(TABOBJS)
-	$(CC) $(CLFAGS) $(LDFLAGS) $^ -o crontab
+	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o crontab
 
 %.o: %.c defs.h $(PROTOS)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c $(DEFS) $< -o $@


### PR DESCRIPTION
introduced in https://github.com/ptchinster/dcron/commit/b2ca901b918029fdfef574d8109aae98aa035111